### PR TITLE
Add modal display logic on card click

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -159,6 +159,13 @@ function getResources(name) {
     };
 }
 
+function updateChart(item) {
+    const chartContainer = document.getElementById('statsChart');
+    if (!chartContainer) return;
+    console.log('Updating chart for', item.name);
+    // Implementation would update chart elements based on item data
+}
+
 function showModal(item) {
     const modal = document.getElementById('infoModal');
     const modalTitle = document.getElementById('modalTitle');
@@ -292,7 +299,13 @@ function createCard(item) {
     card.appendChild(details);
 
     card.addEventListener('click', () => {
-        showModal(item);
+        if (typeof updateChart === 'function') {
+            updateChart(item);
+        }
+        details.classList.toggle('show');
+        if (document.getElementById('infoModal')) {
+            showModal(item);
+        }
     });
 
     return card;


### PR DESCRIPTION
## Summary
- call `updateChart` and toggle details visibility when a card is clicked
- ensure modal elements exist before showing modal
- add placeholder `updateChart` function

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847fb32f3188328945e93cce15ff133