### PR TITLE
Add animated journey timeline and dynamic method traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ The radar chart loads on demand and animates smoothly when a card is selected.
 A mobile bottom navigation bar and floating help button improve the mobile experience.
 The chart now floats on the side of the screen with a toggle to hide or show it.
 It smoothly slides in and out when toggled instead of hiding on scroll.
+Guided journeys now load from an external JSON file and animate as a timeline
+based on the selected method. The radar chart also updates for each approach.

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@motionone/dom/dist/motion.umd.min.js"></script>
 </head>
 <body>
     <header>
@@ -48,13 +49,7 @@
         <section id="journeys">
             <h2>Guided Journeys</h2>
             <p>Core ideas distilled from respected sources to cultivate confident, compassionate leaders.</p>
-            <ul>
-                <li>Encourage independence and responsibility daily.</li>
-                <li>Model empathy and patience through every interaction.</li>
-                <li>Create rhythm and structure to nurture security.</li>
-                <li>Invite curiosity with nature walks, hands-on projects, and storytelling.</li>
-                <li>Share purposeful habits rooted in kindness and resilience.</li>
-            </ul>
+            <div id="journeyTimeline" class="timeline"></div>
         </section>
     </main>
     <div id="infoModal" class="modal">

--- a/journeys.json
+++ b/journeys.json
@@ -1,0 +1,31 @@
+{
+  "Montessori": {
+    "traits": [80,40,90,70,75,60,50],
+    "stages": [
+      {"stage":"Newborn","focus":"Observe cues and offer gentle interaction"},
+      {"stage":"0-6 months","focus":"Prepared environment with simple mobiles"},
+      {"stage":"6-12 months","focus":"Encourage reaching and mobility"},
+      {"stage":"1-2 years","focus":"Practical life: pouring, dressing"},
+      {"stage":"3-6 years","focus":"Child-led exploration and independence"}
+    ]
+  },
+  "Attachment Parenting": {
+    "traits": [85,40,60,70,75,50,40],
+    "stages": [
+      {"stage":"Newborn","focus":"Skin-to-skin bonding and responsiveness"},
+      {"stage":"0-6 months","focus":"Babywearing and co-sleep safety"},
+      {"stage":"6-12 months","focus":"Responsive feeding and gentle play"},
+      {"stage":"1-2 years","focus":"Encourage secure exploration with closeness"}
+    ]
+  },
+  "Waldorf": {
+    "traits": [70,60,50,90,70,60,70],
+    "stages": [
+      {"stage":"Newborn","focus":"Warmth, rhythm, and cuddling"},
+      {"stage":"0-6 months","focus":"Simple natural toys"},
+      {"stage":"6-12 months","focus":"Gentle music and movement"},
+      {"stage":"1-2 years","focus":"Imaginative play and storytelling"},
+      {"stage":"3-6 years","focus":"Nature walks and crafts"}
+    ]
+  }
+}

--- a/scripts.js
+++ b/scripts.js
@@ -77,6 +77,7 @@ const methods = [
     {
         name: 'Montessori',
         summary: 'Self-directed activity in prepared environments.',
+        traits: [80,40,90,70,75,60,50],
         good: 80,
         bad: 30,
         grows: ['independence', 'concentration', 'self-motivation'],
@@ -85,6 +86,7 @@ const methods = [
     {
         name: 'Waldorf',
         summary: 'Arts-based learning with daily rhythm.',
+        traits: [70,60,50,90,70,60,70],
         good: 70,
         bad: 40,
         grows: ['creativity', 'imagination'],
@@ -93,6 +95,7 @@ const methods = [
     {
         name: 'Reggio Emilia',
         summary: 'Project-based child-led discovery.',
+        traits: [75,55,60,85,65,50,45],
         good: 75,
         bad: 35,
         grows: ['collaboration', 'critical thinking'],
@@ -101,6 +104,7 @@ const methods = [
     {
         name: 'Charlotte Mason',
         summary: 'Short lessons using living books.',
+        traits: [65,70,70,60,70,70,75],
         good: 70,
         bad: 30,
         grows: ['love of literature', 'habit formation'],
@@ -109,6 +113,7 @@ const methods = [
     {
         name: 'Unschooling',
         summary: 'Learning from life experiences.',
+        traits: [60,30,80,75,65,45,40],
         good: 65,
         bad: 45,
         grows: ['curiosity', 'independence'],
@@ -117,6 +122,7 @@ const methods = [
     {
         name: 'Forest School',
         summary: 'Outdoor nature-rich exploration.',
+        traits: [70,50,85,80,70,55,40],
         good: 80,
         bad: 30,
         grows: ['resilience', 'environmental awareness'],
@@ -125,6 +131,7 @@ const methods = [
     {
         name: 'Classical Education',
         summary: 'Grammar, Logic, Rhetoric.',
+        traits: [50,80,40,50,65,80,90],
         good: 70,
         bad: 40,
         grows: ['logic', 'memorization'],
@@ -133,6 +140,7 @@ const methods = [
     {
         name: 'RIE',
         summary: 'Respectful infant caregiving.',
+        traits: [90,40,60,60,80,50,40],
         good: 85,
         bad: 20,
         grows: ['autonomy', 'secure attachment'],
@@ -141,6 +149,7 @@ const methods = [
     {
         name: 'Pikler',
         summary: 'Independent motor development.',
+        traits: [80,40,70,50,75,60,40],
         good: 80,
         bad: 25,
         grows: ['confidence', 'motor skills'],
@@ -149,6 +158,7 @@ const methods = [
     {
         name: 'Faith-Based',
         summary: 'Guided by scripture and moral character.',
+        traits: [70,60,50,70,80,70,80],
         good: 85,
         bad: 30,
         grows: ['moral development', 'community'],
@@ -177,6 +187,8 @@ const icons = {
     'Faith-Based': '🙏'
 };
 
+let journeyData = {};
+
 function getExample(name) {
     return `An example of ${name} in action.`;
 }
@@ -199,6 +211,21 @@ function getResources(name) {
 }
 
 function updateChart(item){if(!window.radarChart)return;radarChart.data.datasets[0].label=item.name;radarChart.data.datasets[0].data=item.traits;radarChart.update();}
+
+function updateTimeline(name){
+    const timeline=document.getElementById('journeyTimeline');
+    if(!timeline||!journeyData[name]){timeline.innerHTML='';return;}
+    timeline.innerHTML='';
+    journeyData[name].stages.forEach((s,i)=>{
+        const el=document.createElement('div');
+        el.className='milestone';
+        el.innerHTML=`<h4>${s.stage}</h4><p>${s.focus}</p>`;
+        timeline.appendChild(el);
+        if(window.motion){
+            motion.animate(el,{opacity:[0,1],transform:['translateY(20px)','translateY(0)']},{delay:i*0.1,duration:0.4});
+        }
+    });
+}
 
 function showModal(item) {
     const modal = document.getElementById('infoModal');
@@ -359,6 +386,7 @@ function createCard(item) {
         document.querySelectorAll('.card.active').forEach(c => c.classList.remove('active'));
         card.classList.add('active');
         updateChart(item);
+        updateTimeline(item.name);
     });
 
     return card;
@@ -369,6 +397,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const methodContainer = document.querySelector('#methods .cards');
     styles.forEach(item => styleContainer.appendChild(createCard(item)));
     methods.forEach(item => methodContainer.appendChild(createCard(item)));
+
+    fetch('journeys.json').then(r=>r.json()).then(d=>{journeyData=d;});
 
     let chartInitialized = false;
     const chartObserver = new IntersectionObserver(entries => {

--- a/styles.css
+++ b/styles.css
@@ -326,3 +326,7 @@ header h1, header p {opacity:0; animation: fadeIn 1s forwards;}
 header p {animation-delay:0.5s;}
 @keyframes fadeIn {from{opacity:0} to{opacity:1}}
 
+.timeline {display:flex;flex-direction:column;gap:1rem;margin-top:1rem;}
+.milestone {position:relative;padding:0.5rem 1rem;border-left:2px solid #76a3ff;}
+.milestone::before {content:'';position:absolute;left:-6px;top:0.75rem;width:10px;height:10px;border-radius:50%;background:#76a3ff;}
+


### PR DESCRIPTION
## Summary
- add method trait scores and new journeys dataset
- replace journey bullet list with animated timeline container
- load journey data and update timeline dynamically
- animate milestones with Motion One and update radar chart for each method
- document dynamic timeline feature

## Testing
- `node -p "1+1"`
- `node -e "console.log(Object.keys(require('./journeys.json')).length)"`

------
https://chatgpt.com/codex/tasks/task_e_6848581fd26c8328ab6d9ed25be5df9c