### PR TITLE
Revamp styling with Material 3 look

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,9 @@
     <title>Parent Ally</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
+    <meta name="theme-color" content="#6750a4">
     <link rel="stylesheet" href="styles.css">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@motionone/dom/dist/motion.umd.min.js"></script>

--- a/scripts.js
+++ b/scripts.js
@@ -588,6 +588,15 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
+    document.addEventListener('click', e => {
+        if (!searchInput.contains(e.target) && !suggestions.contains(e.target)) {
+            suggestions.innerHTML = '';
+        }
+    });
+    searchInput.addEventListener('keydown', e => {
+        if (e.key === 'Escape') suggestions.innerHTML = '';
+    });
+
     const themeToggle = document.getElementById('themeToggle');
     if (localStorage.getItem('theme') === 'dark') document.body.classList.add('dark-mode');
     themeToggle.addEventListener('click', () => {

--- a/styles.css
+++ b/styles.css
@@ -1,21 +1,29 @@
 
 body.dark-mode {
-    --bg:#2b2b2b;
-    --text:#f0f0f0;
-    --surface:#3b3b3b;
-    --shadow-light:#454545;
-    --shadow-dark:#1a1a1a;
+    --primary:#d0bcff;
+    --on-primary:#381e72;
+    --surface:#1e1b25;
+    --surface-container:#131218;
+    --on-surface:#e6e1e5;
+    --outline:#938f99;
+    --bg:var(--surface-container);
+    --text:var(--on-surface);
+    --shadow:rgba(0,0,0,0.4);
 }
 
-:root{
-    --bg:#e0e0e0;
-    --text:#333;
-    --surface:#e0e0e0;
-    --shadow-light:#ffffff;
-    --shadow-dark:#bebebe;
+:root {
+    --primary:#6750a4;
+    --on-primary:#ffffff;
+    --surface:#ffffff;
+    --surface-container:#f5f5f5;
+    --on-surface:#1c1b1f;
+    --outline:#79747e;
+    --bg:var(--surface-container);
+    --text:var(--on-surface);
+    --shadow:rgba(0,0,0,0.08);
 }
 body {
-    font-family: 'Inter', Arial, sans-serif;
+    font-family: 'Roboto', 'Inter', Arial, sans-serif;
     font-size: 16px;
     margin: 0;
     padding: 0;
@@ -26,7 +34,7 @@ header {
     text-align: center;
     padding: 2rem 1rem;
     background: var(--surface);
-    box-shadow: 6px 6px 12px var(--shadow-dark), -6px -6px 12px var(--shadow-light);
+    box-shadow: 0 2px 4px var(--shadow);
 }
 header h1 {
     margin: 0.2rem;
@@ -53,7 +61,7 @@ main {
 .card {
     background: var(--surface);
     border-radius: 12px;
-    box-shadow: 6px 6px 12px var(--shadow-dark), -6px -6px 12px var(--shadow-light);
+    box-shadow: 0 1px 3px var(--shadow);
     padding: 1rem;
     width: calc(33% - 1rem);
     box-sizing: border-box;
@@ -73,7 +81,7 @@ main {
 }
 .card:hover {
     transform: translateY(-5px);
-    box-shadow: 8px 8px 16px var(--shadow-dark), -8px -8px 16px var(--shadow-light);
+    box-shadow: 0 4px 8px var(--shadow);
 }
 .details {
     margin-top: 0.5rem;
@@ -82,6 +90,7 @@ main {
     margin: 0.5rem 0 0.2rem;
     font-size: 1rem;
 }
+.details summary { cursor: pointer; }
 .details ul {
     margin: 0 0 0.5rem 1.2rem;
     padding: 0;
@@ -98,7 +107,7 @@ main {
 }
 .meter div {
     height: 100%;
-    background: #76a3ff;
+    background: var(--primary);
 }
 
 .meter-container {
@@ -153,7 +162,7 @@ footer {
     text-align: center;
     padding: 1rem;
     background: var(--surface);
-    box-shadow: inset 6px 6px 12px var(--shadow-dark), inset -6px -6px 12px var(--shadow-light);
+    box-shadow: inset 0 1px 2px var(--shadow);
 }
 @media (max-width: 600px) {
     .card {
@@ -172,14 +181,14 @@ footer {
     padding: 0.5rem 1rem;
     border-radius: 20px;
     border: none;
-    box-shadow: inset 3px 3px 6px var(--shadow-dark), inset -3px -3px 6px var(--shadow-light);
+    box-shadow: inset 0 1px 2px var(--shadow);
     margin-right: 0.5rem;
 }
 #themeToggle {
     padding: 0.5rem 1rem;
     border-radius: 20px;
     border: none;
-    box-shadow: 3px 3px 6px var(--shadow-dark), -3px -3px 6px var(--shadow-light);
+    box-shadow: 0 1px 2px var(--shadow);
 }
 
 /* Sidebar navigation */
@@ -192,7 +201,7 @@ footer {
     border: none;
     padding: 0.5rem;
     border-radius: 8px;
-    box-shadow: 3px 3px 6px var(--shadow-dark), -3px -3px 6px var(--shadow-light);
+    box-shadow: 0 1px 3px var(--shadow);
 }
 #sidebar {
     position: fixed;
@@ -201,7 +210,7 @@ footer {
     width: 180px;
     height: 100%;
     background: var(--surface);
-    box-shadow: 6px 0 12px var(--shadow-dark);
+    box-shadow: 0 2px 4px var(--shadow);
     padding-top: 4rem;
     transition: left 0.3s ease;
     z-index: 1050;
@@ -220,7 +229,7 @@ footer {
     height: 300px;
     background: var(--surface);
     border-radius: 12px;
-    box-shadow: 6px 6px 12px var(--shadow-dark), -6px -6px 12px var(--shadow-light);
+    box-shadow: 0 2px 4px var(--shadow);
     overflow: hidden;
     z-index: 1000;
     transition: transform 0.3s ease, opacity 0.3s ease;
@@ -243,7 +252,7 @@ footer {
     padding: 0.4rem 0.8rem;
     border-radius: 8px;
     background: var(--surface);
-    box-shadow: 3px 3px 6px var(--shadow-dark), -3px -3px 6px var(--shadow-light);
+    box-shadow: 0 1px 2px var(--shadow);
     cursor: pointer;
     transition: right 0.3s ease;
 }
@@ -283,7 +292,7 @@ footer {
 
 .card.active {
     transform: scale(1.02);
-    box-shadow: 8px 8px 16px var(--shadow-dark), -8px -8px 16px var(--shadow-light);
+    box-shadow: 0 4px 8px var(--shadow);
 }
 .details { max-height: 0; overflow: hidden; transition: max-height 0.3s ease; }
 .card.active .details { max-height: 200px; }
@@ -298,7 +307,7 @@ footer {
     right: 0;
     background: var(--surface);
     padding: 0.5rem 0;
-    box-shadow: 0 -2px 8px var(--shadow-dark);
+    box-shadow: 0 -2px 8px var(--shadow);
 }
 #bottomNav a { text-decoration: none; color: inherit; font-size: 0.9rem; }
 
@@ -309,7 +318,7 @@ footer {
     border: none;
     padding: 0.6rem 1rem;
     border-radius: 20px;
-    box-shadow: 3px 3px 6px var(--shadow-dark), -3px -3px 6px var(--shadow-light);
+    box-shadow: 0 1px 2px var(--shadow);
     background: var(--surface);
     cursor: pointer;
 }
@@ -321,7 +330,7 @@ footer {
     max-height: 150px;
     overflow-y: auto;
     background: var(--surface);
-    box-shadow: 3px 3px 6px var(--shadow-dark), -3px -3px 6px var(--shadow-light);
+    box-shadow: 0 1px 2px var(--shadow);
 }
 .suggestions li { padding: 0.3rem 0.5rem; cursor: pointer; }
 .suggestions li:hover { background: #ddd; }
@@ -337,6 +346,6 @@ header p {animation-delay:0.5s;}
 @keyframes fadeIn {from{opacity:0} to{opacity:1}}
 
 .timeline {display:flex;flex-direction:column;gap:1rem;margin-top:1rem;}
-.milestone {position:relative;padding:0.5rem 1rem;border-left:2px solid #76a3ff;}
-.milestone::before {content:'';position:absolute;left:-6px;top:0.75rem;width:10px;height:10px;border-radius:50%;background:#76a3ff;}
+.milestone {position:relative;padding:0.5rem 1rem;border-left:2px solid var(--primary);}
+.milestone::before {content:'';position:absolute;left:-6px;top:0.75rem;width:10px;height:10px;border-radius:50%;background:var(--primary);}
 


### PR DESCRIPTION
## Summary
- switch to Roboto font and import Material symbols
- add theme color meta
- use Material 3 style variables and softer shadows
- color meters and timeline using the primary color
- close search suggestions when clicking outside or pressing `Esc`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848a2f620c88328855d476c39d409bd